### PR TITLE
view-token replaces both view-macaroon and view-jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ Script to obtain a macaroon (bearer token) from a dCache WebDAV door. Macaroons 
 ## view-macaroon
 
 Script to deserialise a macaroon (to see its properties).
+
+## view-token
+
+New version of get-macaroon. Decodes both macaroons and OIDC tokens, and does some validation.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Script to obtain a macaroon (bearer token) from a dCache WebDAV door. Macaroons 
 
 ## view-macaroon
 
-Script to deserialise a macaroon (to see its properties).
+(Deprecated; use view-token instead) Script to deserialise a macaroon (to see its properties).
 
 ## view-token
 
-New version of get-macaroon. Decodes both macaroons and OIDC tokens, and does some validation.
+New version of view-macaroon. Decodes both macaroons and OIDC tokens, and does some validation.

--- a/get-macaroon
+++ b/get-macaroon
@@ -247,7 +247,7 @@ case $auth_method in
     if [ -x "$(command -v voms-proxy-info)" ]; then
       voms-proxy-info --exists 1>&2 || exit 1
     fi
-    authn="--capath /etc/grid-security/certificates/ --cert '$X509_USER_PROXY' --cacert '$X509_USER_PROXY'"
+    authn="--capath /etc/grid-security/certificates/ --cert $X509_USER_PROXY --cacert $X509_USER_PROXY"
     ;;
   user )
     authn="-u $user"

--- a/get-macaroon
+++ b/get-macaroon
@@ -430,10 +430,10 @@ if [ -x "${script_dir}/view-token" ] ; then
 else
   macaroon_viewer="$(command -v view-token)"
 fi
-echo 1>&2 "Macaroon viewer: $macaroon_viewer"
-# The <(cat) construction is to prevent the macaroon to be visible with the 'ps' command.
-macaroon_decoded=$($macaroon_viewer --minimal <(cat <<<"$macaroon") )
 if [ -x "$macaroon_viewer" ] ; then
+  echo 1>&2 "Macaroon viewer: $macaroon_viewer"
+  # The <(cat) construction is to prevent the macaroon to be visible with the 'ps' command.
+  macaroon_decoded=$($macaroon_viewer --minimal <(cat <<<"$macaroon") )
   {
     echo "=== View deserialized macaroon ==="
     echo "$macaroon_decoded"
@@ -448,6 +448,14 @@ if [ -x "$macaroon_viewer" ] ; then
     echo -e "=====================================\n"
   } >> ~/macaroons.log
   chmod 600 ~/macaroons.log
+else
+  {
+    echo
+    echo "Warning: could not find command view-token." \
+         "Unable to show or log the macaroon properties."
+    echo "Install view-token (from the same repo as get-macaroon) to get rid of this message."
+    echo
+  } 1>&2
 fi
 
 

--- a/get-macaroon
+++ b/get-macaroon
@@ -10,8 +10,8 @@
 # Old versions available at:
 # https://github.com/onnozweers/dcache-scripts/blob/master/get-share-link
 #
-# Uses a script called view-macaroon, which is available here:
-# https://github.com/sara-nl/GridScripts/blob/master/view-macaroon
+# Uses a script called view-token, which is available here:
+# https://github.com/sara-nl/GridScripts/blob/master/view-token
 #
 # Changes:
 # 2018-06-22 - Onno - Initial version

--- a/get-macaroon
+++ b/get-macaroon
@@ -352,7 +352,8 @@ if $debug ; then
             "$authn " \
             "-X POST -H 'Content-Type: application/macaroon-request' " \
             "-d \'$json_request\' " \
-            "$server "
+            "$server " \
+            "--dump-header >(grep '^HTTP/1.1' | grep -v '200' >&2)"
 fi
 
 
@@ -360,9 +361,13 @@ result=$(curl --silent \
               $authn \
               -X POST -H 'Content-Type: application/macaroon-request' \
               -d "$json_request" \
-              $server )
+              $server \
+              --dump-header >(grep '^HTTP/1.1' | grep -v '200' >&2)
+        )
+
 
 if ! echo "$result" | grep --silent "targetWithMacaroon" ; then
+  # No macaroon was returned. Print possible error messages to stderr.
   {
     echo "ERROR: could not get share link from $server."
     # Show output from server in the nicest way possible

--- a/get-macaroon
+++ b/get-macaroon
@@ -353,15 +353,20 @@ if $debug ; then
             "-X POST -H 'Content-Type: application/macaroon-request' " \
             "-d \'$json_request\' " \
             "$server " \
+            "--fail --show-error " \
             "--dump-header >(grep '^HTTP/1.1' | grep -v '200' >&2)"
 fi
 
-
+# This is where we actually obtain the macaroon from the dCache WebDAV door.
+# We use --fail, --show-error and --dump-header to show clear error messages.
+# --fail --show-error will show connection errors ("Could not resolve host")
+# --dump-header will show the HTTP code and its description ("HTTP/1.1 401 login failed").
 result=$(curl --silent \
               $authn \
               -X POST -H 'Content-Type: application/macaroon-request' \
               -d "$json_request" \
               $server \
+              --fail --show-error \
               --dump-header >(grep '^HTTP/1.1' | grep -v '200' >&2)
         )
 

--- a/get-macaroon
+++ b/get-macaroon
@@ -29,6 +29,11 @@
 # 2020-03-07 - Onno - Added --netrc option
 # 2020-03-09 - Onno - Check for view-macaroon in same dir as get-macaroon
 # 2020-03-31 - Juan Luis Font Calvo - Fix html2text call
+# 2025-08-13 - Onno - Show better error messages
+# 2025-08-13 - Onno - Fix token authentication
+# 2025-08-13 - Onno - Improve quoting and other things suggested by ShellCheck
+# 2025-08-13 - Onno - Use view-token instead of view-macaroon
+
 
 usage() {
   cat <<-EOF
@@ -37,10 +42,13 @@ usage() {
 	Options are:
 	  --url <url>
 	  --chroot               - Make specified path the root diectory, hiding upper dirs
-	  --proxy                - Use proxy specified in X509_USER_PROXY
+	  --proxy                - Use X509 proxy specified in X509_USER_PROXY
 	  --user <username>      - Username/password authentication
 	  --netrc [filename]     - Authenticate with a curl netrc file.
 	                           If no filename was provided, use ~/.netrc.
+	  --tokenfile <file>     - Read input authentication token from this file
+	                           If no authentication method is specified,
+	                           get-macaroon will try to use \$BEARER_TOKEN.
 	  --permissions <list>   - Comma separated list of allowed activities. Example:
 	                           DOWNLOAD,LIST
 	                           These permissions can be given:
@@ -52,17 +60,17 @@ usage() {
 	                           STAGE    - Stage (restore) a file from tape
 	                           READ_METADATA   - Read file status
 	                           UPDATE_METADATA - Change properties, change QoS
-	  --duration             - Duration that the link will be valid, in ISO8601 format
+	  --duration             - Duration that the link or macaroon will be valid, in ISO8601 format
 	                           See https://en.wikipedia.org/wiki/ISO_8601#Durations
 	                           The duration may be limited by the server.
-	  --ip <subnet-list>     - Allow access from these addresses/subnets.
+	  --ip <subnet-list>     - Allow access from these addresses/subnets only.
 	                           Multiple subnets may be specified, comma separated.
 	                           Don't forget IPv6.
 	                           The person whom the macaroon is for, can find the
 	                           external addresses of his/her system with this command:
 	                           curl -4 icanhazip.com ; curl -6 icanhazip.com
 	                           or by browsing to https://whatismyipaddress.com/.
-	  --max-file-size        - Set a maximum file size for uploads. dCache 5 required.
+	  --max-file-size        - Set a maximum file size for uploads.
 	  --output link          - Print a link that anyone can open in a browser.
 	                           If you open the link in your browser, please do it in 
 	                           a new private window, to be certain you're authenticated
@@ -118,7 +126,7 @@ while [ $# -gt 0 ] ; do
   case "$1" in
     --url )
       url="$2"
-      shift 2
+      shift ; shift
       ;;
     --chroot )
       path_or_root="root"
@@ -148,21 +156,27 @@ while [ $# -gt 0 ] ; do
       auth_method=proxy
       shift
       ;;
+    --tokenfile )
+      auth_method=token
+      tokenfile="$2"
+      token=$(<"$tokenfile")
+      shift ; shift
+      ;;
     --permissions )
       activity="$2"
-      shift 2
+      shift ; shift
       ;;
     --duration )
       duration="$2"
-      shift 2
+      shift ; shift
       ;;
     --ip )
       ip="$2"
-      shift 2
+      shift ; shift
       ;;
     --max-file-size )
       max_file_size="$2"
-      shift 2
+      shift ; shift
       ;;
     --output )
       output="$2"
@@ -197,36 +211,51 @@ if [ -z "$url" ] ; then
   usage
 fi
 
+
+if [ -z "$auth_method" ] ; then
+  # User did not specify authentication method. Let's try if BEARER_TOKEN is set and use that.
+  if [ -n "$BEARER_TOKEN" ] ; then
+    echo 1>&2 "Using \$BEARER_TOKEN for authentication."
+    token="$BEARER_TOKEN"
+    auth_method='token'
+  else
+    echo 1>&2 "ERROR: no authentication method was specified, and BEARER_TOKEN is not set."
+    exit 1
+  fi
+fi
+
+
 case $auth_method in
   netrc )
     if [ ! -f "$netrcfile" ] ; then
-      echo "ERROR: could not open netrc file '$netrcfile'."
+      echo 1>&2 "ERROR: could not open netrc file '$netrcfile'."
       exit 1
     fi
     authn="--netrc-file $netrcfile"
     ;;
   proxy )
     if [ ! -f "$X509_USER_PROXY" ] ; then
-      echo "ERROR: could not open proxy '$X509_USER_PROXY'."
+      echo 1>&2 "ERROR: could not open proxy '$X509_USER_PROXY'."
       exit 1
     fi
     if [ ! -d /etc/grid-security/certificates ] ; then
-      echo "ERROR: could not find /etc/grid-security/certificates/." \
-           "Please install the Grid root certificates if you want to use your proxy."
+      echo 1>&2 "ERROR: could not find /etc/grid-security/certificates/." \
+                "Please install the Grid root certificates if you want to use your proxy."
       exit 1
     fi
     # Check if the proxy is still valid; if not, exit after the error message.
     if [ -x "$(command -v voms-proxy-info)" ]; then
       voms-proxy-info --exists 1>&2 || exit 1
     fi
-    authn="--capath /etc/grid-security/certificates/ --cert $X509_USER_PROXY --cacert $X509_USER_PROXY"
+    authn="--capath /etc/grid-security/certificates/ --cert '$X509_USER_PROXY' --cacert '$X509_USER_PROXY'"
     ;;
   user )
     authn="-u $user"
     ;;
   token )
     # We can't specify the token as a command line argument,
-    # because others could read that with the ps command.
+    # because other users on the same system could read the token
+    # with the ps command and steal and abuse it.
     # So we have to put the authorization header in a temporary file.
     # The mktemp command differs on OSX.
     curl_authorization_header_file=$(mktemp authorization_header_XXXXXXXXXXXX)
@@ -249,13 +278,13 @@ case $auth_method in
     authn="--config $curl_authorization_header_file"
     ;;
   * )
-    echo "ERROR: you have to specify a valid authentication method."
+    echo 1>&2 "ERROR: you have to specify a valid authentication method."
     exit 1
     ;;
 esac
 
 
-server=$(echo "$url" | egrep -o 'https://[^/]+/')
+server=$(echo "$url" | grep -E -o 'https://[^/]+/')
 dir=$(echo "$url" | sed -e 's#https://[^/]*##')
 if [ -z "$dir" ] ; then
   dir=/
@@ -285,9 +314,10 @@ case $OSTYPE in
     ;;
 esac
 
+# Additional validation based on the output format
 case $output in
-  link|macaroon|curl )
-    # output format OK
+  link | macaroon | curl )
+    # No extra validation needed
     ;;
   file )
     if [ -z "$filename" ] ; then
@@ -349,10 +379,10 @@ if $debug ; then
   echo
   echo "Curl command:"
   echo "curl --silent " \
-            "$authn " \
+            "$authn" \
             "-X POST -H 'Content-Type: application/macaroon-request' " \
             "-d \'$json_request\' " \
-            "$server " \
+            "'$server' " \
             "--fail --show-error " \
             "--dump-header >(grep '^HTTP/1.1' | grep -v '200' >&2)"
 fi
@@ -365,7 +395,7 @@ result=$(curl --silent \
               $authn \
               -X POST -H 'Content-Type: application/macaroon-request' \
               -d "$json_request" \
-              $server \
+              "$server" \
               --fail --show-error \
               --dump-header >(grep '^HTTP/1.1' | grep -v '200' >&2)
         )
@@ -395,26 +425,26 @@ macaroon=$(echo "$result" | jq -r '.macaroon')
 link=$(echo "$result" | jq -r '.uri.targetWithMacaroon')
 
 # Show contents of macaroon
-if [ -x "${script_dir}/view-macaroon" ] ; then
-  macaroon_viewer="${script_dir}/view-macaroon"
+if [ -x "${script_dir}/view-token" ] ; then
+  macaroon_viewer="${script_dir}/view-token"
 else
-  macaroon_viewer="$(command -v view-macaroon)"
+  macaroon_viewer="$(command -v view-token)"
 fi
-echo "Macaroon viewer: $macaroon_viewer"
+echo 1>&2 "Macaroon viewer: $macaroon_viewer"
+# The <(cat) construction is to prevent the macaroon to be visible with the 'ps' command.
+macaroon_decoded=$($macaroon_viewer --minimal <(cat <<<"$macaroon") )
 if [ -x "$macaroon_viewer" ] ; then
-  BLUE=$'\e[34m'
-  RESET=$'\e[39m'
-  echo -e "$BLUE"
-  echo "=== View deserialized macaroon ==="
-  $macaroon_viewer <<<"$macaroon"
-  echo "=== End deserialized macaroon ==="
-  echo -e "$RESET"
-  echo
+  {
+    echo "=== View deserialized macaroon ==="
+    echo "$macaroon_decoded"
+    echo "=== End deserialized macaroon ==="
+    echo
+  } 1>&2
   #
-  # Log macaroon properties in a (private) file; strip signature to prevent theft
+  # Log macaroon properties in a (private) file
   {
     echo "=== $(date) ==="
-    $macaroon_viewer <<<"$macaroon" | grep -v signature
+    echo "$macaroon_decoded"
     echo -e "=====================================\n"
   } >> ~/macaroons.log
   chmod 600 ~/macaroons.log
@@ -428,6 +458,8 @@ case $output in
     ;;
   macaroon )
     # Just the bare token, nothing else
+    # It's important that all other output is sent to stderr, so users can do this:
+    # export BEARER_TOKEN=$(get-macaroon ... --output macaroon)
     echo "$macaroon"
     ;;
   file )
@@ -464,7 +496,7 @@ case $output in
     echo "Creating rclone config file $remote_name.conf:"
     echo
     $debug && echo "rclone --config=$remote_name.conf config create $remote_name webdav url $server vendor other user '' password '' bearer_token $macaroon"
-    rclone --config=$remote_name.conf config create $remote_name webdav url $server vendor other user '' password '' bearer_token $macaroon
+    rclone --config="$remote_name.conf" config create "$remote_name" webdav url "$server" vendor other user '' password '' bearer_token "$macaroon"
     echo
     echo "Send this file to the persons you want to share data with."
     echo "They need rclone v1.42-012-gfa051ff9 or newer to access the data."
@@ -477,13 +509,13 @@ case $output in
     fi
     # Generate QR image
     echo "Creating QR image file: $png_filename"
-    if qrencode -o $png_filename "$link" ; then
+    if qrencode -o "$png_filename" "$link" ; then
       # If the name is "display[.png]", the user wants to see it now!
       if [ "$png_filename" = "display.png" ] ; then
         # Try to open it in an image viewer
         for imageviewer in feh display xdg-open eog Xming ; do
           if [ -x "$(command -v $imageviewer)" ] ; then
-            $imageviewer $png_filename
+            $imageviewer "$png_filename"
             break
           fi
         done
@@ -491,7 +523,7 @@ case $output in
         echo "Created QR image file: $png_filename"
       fi
     else
-      echo "ERROR: Could not create QR file."
+      echo 1>&2 "ERROR: Could not create QR file."
       exit 1
     fi
     ;;

--- a/view-token
+++ b/view-token
@@ -193,9 +193,9 @@ else
   # No tokenfile specified. Let's try BEARER_TOKEN.
   if [ -n "$BEARER_TOKEN" ] ; then
     token="$BEARER_TOKEN"
-    echo "Token source: BEARER_TOKEN variable"
+    $verbose && echo "Token source: BEARER_TOKEN variable"
   else
-    echo "No tokenfile specified, and BEARER_TOKEN is empty. Nothing to do."
+    echo 1>&2 "No tokenfile specified, and BEARER_TOKEN is empty. Nothing to do."
     exit 1
   fi
   # read BEARER_TOKEN

--- a/view-token
+++ b/view-token
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-debug=false
-
 # view-token
 #
 # This script can decode and show macaroons and OIDC (JWT) tokens.
@@ -15,58 +13,21 @@ usage() {
 	<filename>     - file containing a token. Can be a plain text file with the bare token,
 	                 or an Rclone config file. In that case, view-token will search for
 	                 a line containing "bearer_token" and decode the value.
+	                 You can use a trick like this:
+	                     view-token <(cat <<<"\$my_token")
+	                 This allows you to read from a variable without exposing the variable
+	                 to other users with the ps command.
 
 	<no filename>  - view-token will look for environment variable BEARER_TOKEN
 	                 and decode its value.
 
-	--debug        - Show additional information.
+	--minimal      - Show only minimal information.
+
+	--help         - Show this help text.
 
 	EOF
 }
 
-
-
-view_token() {
-  local token="$1"
-  local token_debug_info="$2"
-
-  echo "$token_debug_info"
-
-  # Determine token type (JWT or Macaroon)
-  if [[ "$token" =~ ^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$ ]]; then
-    # JWT / OIDC token.
-
-    # Get payload with the token properties.
-    payload=$(echo "$token" | cut -d "." -f2 | base64 -d 2>/dev/null | tr -d '\n')
-
-    # Check if decoding succeeded
-    if [ -z "$payload" ]; then
-      echo "Invalid token: cannot decode payload"
-      return 1
-    fi
-
-    # Print JWT/OIDC token with human readable timestamps
-    echo "Token is an OIDC token."
-    echo "$payload" | jq '. | .exp |= todate | .nbf |= todate | .iat |= todate'
-  else
-    # Not an OIDC token; probably a Macaroon
-    # We use grep with --text to avoid a "Binary file" message.
-    macaroon_decoded=$(echo "$token" \
-                       | base64 -d 2>/dev/null \
-                       | awk '{print substr($0, 5)}' 2>/dev/null \
-                       | grep --text -v 'signature' \
-                       | tr -d '\0')
-
-    # Check if decoding succeeded
-    if [ -z "$macaroon_decoded" ]; then
-      echo "Invalid macaroon: cannot decode"
-      return 1
-    fi
-
-    echo "Token is a macaroon."
-    echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | sed -e 's/^/  /'
-  fi
-}
 
 
 validate_expiration_timestamp () {
@@ -127,7 +88,7 @@ check_token() {
     fi
 
     # If we get here, it means we have a valid OIDC token.
-    "JWT / OIDC token is still valid"
+    $verbose && echo "JWT / OIDC token is still valid"
     return 0
 
   else
@@ -146,7 +107,11 @@ check_token() {
     fi
 
     # Show the macaroon
-    echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | sed -e 's/^/  /'
+    if $verbose ; then
+      echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | sed -e 's/^/  /'
+    else
+      echo -e "\033[34m$macaroon_decoded\033[0m" | sed -e 's/^/  /'
+    fi
 
     # Extract expiration time (before) using regex
     exp=$(echo "$macaroon_decoded" | grep -o 'before:[0-9T:\.-]*Z' | sed -e 's/before://')
@@ -175,24 +140,45 @@ check_token() {
     fi
 
     # If we get here, it means we have a valid macaroon.
-    echo "Macaroon is still valid"
+    $verbose && echo "Macaroon is still valid"
     return 0
   fi
 }
 
 
-if [ -n "$1" ] ; then
-  tokenfile="$1"
-  echo "Token source: $tokenfile"
+# Read command line arguments.
+tokenfile=''
+verbose=true
+while [ $# -gt 0 ] ; do
+  # Argument can either be '--minimal' or a file name.
+  case "$1" in
+    --minimal )
+      verbose=false
+      shift
+      ;;
+    --help )
+      usage
+      exit 1
+      ;;
+    * )
+      tokenfile="$1"
+      shift
+      ;;
+  esac
+done
+
+
+if [ -n "$tokenfile" ] ; then
+  $verbose && echo "Token source: $tokenfile"
   #
-  # Let's check the file with the token.
-  if ! [ -f "$tokenfile" ] ; then
-    echo 1>&2 "ERROR: specified tokenfile '$tokenfile' does not exist."
+  # Read the tokenfile only once (It might be a file descriptor that will be closed after reading)
+  tokenfile_contents=$(<"$tokenfile") || {
+    echo "ERROR: unable to read token from '$tokenfile'" 1>&2
     exit 1
-  fi
+  }
   #
   # First, we assume the tokenfile is an Rclone config file.
-  token=$(sed -n 's/^bearer_token *= *//p' "$tokenfile")
+  token=$(sed -n 's/^bearer_token *= *//p' <<<"$tokenfile_contents")
   if [ "$(wc -l <<<"$token")" -gt 1 ] ; then
     echo 1>&2 "ERROR: file '$tokenfile' contains multiple tokens. Can't determine which one to show."
     exit 1
@@ -200,10 +186,11 @@ if [ -n "$1" ] ; then
   # If it was not an rclone config file, it may be a
   # plain text file with only the token.
   if [ -z "$token" ] ; then
-    token=$(head -n 1 "$tokenfile")
+    token=$(head -n 1 <<<"$tokenfile_contents")
   fi
 
 else
+  # No tokenfile specified. Let's try BEARER_TOKEN.
   if [ -n "$BEARER_TOKEN" ] ; then
     token="$BEARER_TOKEN"
     echo "Token source: BEARER_TOKEN variable"
@@ -214,5 +201,4 @@ else
   # read BEARER_TOKEN
 fi
 
-#view_token  "$token" || exit 1
 check_token "$token" || exit 1

--- a/view-token
+++ b/view-token
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+
+debug=false
+
+# view-token
+#
+# This script can decode and show macaroons and OIDC (JWT) tokens.
+
+usage() {
+  cat <<-EOF
+	view-token - a script to view the properties of macaroons and OIDC tokens.
+
+	Arguments:
+
+	<filename>     - file containing a token. Can be a plain text file with the bare token,
+	                 or an Rclone config file. In that case, view-token will search for
+	                 a line containing "bearer_token" and decode the value.
+
+	<no filename>  - view-token will look for environment variable BEARER_TOKEN
+	                 and decode its value.
+
+	--debug        - Show additional information.
+
+	EOF
+}
+
+
+
+view_token() {
+  local token="$1"
+  local token_debug_info="$2"
+
+  echo "$token_debug_info"
+
+  # Determine token type (JWT or Macaroon)
+  if [[ "$token" =~ ^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$ ]]; then
+    # JWT / OIDC token.
+
+    # Get payload with the token properties.
+    payload=$(echo "$token" | cut -d "." -f2 | base64 -d 2>/dev/null | tr -d '\n')
+
+    # Check if decoding succeeded
+    if [ -z "$payload" ]; then
+      echo "Invalid token: cannot decode payload"
+      return 1
+    fi
+
+    # Print JWT/OIDC token with human readable timestamps
+    echo "Token is an OIDC token."
+    echo "$payload" | jq '. | .exp |= todate | .nbf |= todate | .iat |= todate'
+  else
+    # Not an OIDC token; probably a Macaroon
+    # We use grep with --text to avoid a "Binary file" message.
+    macaroon_decoded=$(echo "$token" \
+                       | base64 -d 2>/dev/null \
+                       | awk '{print substr($0, 5)}' 2>/dev/null \
+                       | grep --text -v 'signature' \
+                       | tr -d '\0')
+
+    # Check if decoding succeeded
+    if [ -z "$macaroon_decoded" ]; then
+      echo "Invalid macaroon: cannot decode"
+      return 1
+    fi
+
+    echo "Token is a macaroon."
+    echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | sed -e 's/^/  /'
+  fi
+}
+
+
+validate_expiration_timestamp () {
+  local exp_unix="$1"           # Expiration timestamp (unix format)
+  local min_valid_time=60       # Token should be valid for more than this many seconds
+
+  # Do we actually have an expiration timestamp?
+  if [ -z "$exp_unix" ] || ! [[ "$exp_unix" =~ ^[0-9]+$ ]]; then
+    echo 1>&2 "ERROR: Invalid token: missing or invalid expiration field"
+    return 1
+  fi
+
+  # Get the current time in seconds since epoch
+  now=$(date +%s)
+
+  # Check if the token is expired
+  if [ "$now" -ge "$exp_unix" ]; then
+    echo 1>&2 "Token has expired $(( now - exp_unix )) seconds ago."
+    return 1
+  fi
+
+  # Check if the token is about to expire
+  if [ "$now" -ge "$(( exp_unix - min_valid_time ))" ]; then
+    echo 1>&2 "Warning: Token will expire in $(( exp_unix - now )) seconds."
+    return 1
+  fi
+
+  # If we get here, the expiration timestamp should be valid.
+  return 0
+}
+
+
+check_token() {
+  local token="$1"
+  local token_debug_info="$2"
+
+  # Determine token type (JWT or Macaroon)
+  if [[ "$token" =~ ^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$ ]]; then
+    # JWT / OIDC token
+    payload=$(echo "$token" | cut -d "." -f2 | base64 -d 2>/dev/null | tr -d '\n')
+
+    # Check if decoding succeeded
+    if [ -z "$payload" ]; then
+      echo 1>&2 "ERROR: Invalid token: cannot decode payload"
+      return 1
+    fi
+
+    # Show JWT / OIDC token
+    echo "$payload" | jq '. | .exp |= todate | .nbf |= todate | .iat |= todate'
+
+    # Extract expiration time (exp) from payload
+    exp_unix=$(echo "$payload" | jq -r '.exp' 2>/dev/null)
+
+    # Fail if the token has (almost) expired
+    if ! validate_expiration_timestamp "$exp_unix" "$token_debug_info" ; then
+      echo 1>&2 "JWT/OIDC token is no longer valid."
+      return 1
+    fi
+
+    # If we get here, it means we have a valid OIDC token.
+    "JWT / OIDC token is still valid"
+    return 0
+
+  else
+    # Macaroon Token (assume it's base64 encoded)
+    # We use grep with --text to avoid a "Binary file" message.
+    macaroon_decoded=$(echo "$token" \
+                       | base64 -d 2>/dev/null \
+                       | awk '{print substr($0, 5)}' 2>/dev/null \
+                       | grep --text -v 'signature' \
+                       | tr -d '\0')
+
+    # Check if decoding succeeded
+    if [ -z "$macaroon_decoded" ]; then
+      echo 1>&2 "ERROR: Invalid token: cannot decode"
+      return 1
+    fi
+
+    # Show the macaroon
+    echo -e "\033[34m\n$macaroon_decoded\n\033[0m" | sed -e 's/^/  /'
+
+    # Extract expiration time (before) using regex
+    exp=$(echo "$macaroon_decoded" | grep -o 'before:[0-9T:\.-]*Z' | sed -e 's/before://')
+
+    # Validate expiration field
+    if [ -z "$exp" ]; then
+      echo 1>&2 "ERROR: invalid macaroon: missing 'before' field"
+      return 1
+    fi
+
+    # Convert expiration time to unix time (seconds since epoch)
+    case $OSTYPE in
+      darwin* )  exp_unix=$(date -u -j -f "%Y-%m-%dT%H:%M:%S" "${exp:0:19}" +"%s" 2>/dev/null)  ;;
+            * )  exp_unix=$(date -d "$exp" +%s 2>/dev/null)  ;;
+    esac
+
+    if [ -z "$exp_unix" ]; then
+      echo 1>&2 "ERROR: invalid macaroon: unable to parse 'before' timestamp"
+      return 1
+    fi
+
+    # Fail if the token has (almost) expired
+    if ! validate_expiration_timestamp "$exp_unix" "$token_debug_info" ; then
+      echo 1>&2 "Macaroon is no longer valid."
+      return 1
+    fi
+
+    # If we get here, it means we have a valid macaroon.
+    echo "Macaroon is still valid"
+    return 0
+  fi
+}
+
+
+if [ -n "$1" ] ; then
+  tokenfile="$1"
+  echo "Token source: $tokenfile"
+  #
+  # Let's check the file with the token.
+  if ! [ -f "$tokenfile" ] ; then
+    echo 1>&2 "ERROR: specified tokenfile '$tokenfile' does not exist."
+    exit 1
+  fi
+  #
+  # First, we assume the tokenfile is an Rclone config file.
+  token=$(sed -n 's/^bearer_token *= *//p' "$tokenfile")
+  if [ "$(wc -l <<<"$token")" -gt 1 ] ; then
+    echo 1>&2 "ERROR: file '$tokenfile' contains multiple tokens. Can't determine which one to show."
+    exit 1
+  fi
+  # If it was not an rclone config file, it may be a
+  # plain text file with only the token.
+  if [ -z "$token" ] ; then
+    token=$(head -n 1 "$tokenfile")
+  fi
+
+else
+  if [ -n "$BEARER_TOKEN" ] ; then
+    token="$BEARER_TOKEN"
+    echo "Token source: BEARER_TOKEN variable"
+  else
+    echo "No tokenfile specified, and BEARER_TOKEN is empty. Nothing to do."
+    exit 1
+  fi
+  # read BEARER_TOKEN
+fi
+
+#view_token  "$token" || exit 1
+check_token "$token" || exit 1


### PR DESCRIPTION
`view-token` is a new script to view tokens. It is meant to replace `view-macaroon` and `view-jwt`.

* It is written without pymacaroon, which seems hard to install these days.
* It does some validation, mainly whether the token is still valid
* It recognises both OIDC tokens and macaroons and will decode accordingly
* It hides the signature from macaroons for security reasons
* It will not accept tokens on the command line for security reasons; instead it accepts a token file, otherwise will read BEARER_TOKEN environment variable.

Fixes #7.

Also in this pull request: better error messages in `get-macaroon`. (Yes, should have been a separate PR, sorry)