### PR TITLE
If file is `-`, read from stdin

### DIFF
--- a/view-token
+++ b/view-token
@@ -16,7 +16,7 @@ usage() {
 	                 If filename is "-" (dash), view-token will read the token from stdin.
 	                 To read the token in a safe way from an environment variable,
 	                 you can use this trick:
-	                     view-token <(cat <<<"\$my_token")
+	                     view-token - <<<"\$my_token"
 	                 This will not expose your token to other users with the ps command.
 
 	<no filename>  - view-token will look for environment variable BEARER_TOKEN

--- a/view-token
+++ b/view-token
@@ -348,8 +348,8 @@ if [ -n "$tokenfile" ] ; then
   #
   # Read the tokenfile only once (It might be a file descriptor that will be closed after reading)
   if [ "$tokenfile" = "-" ]; then
-    echo "Reading token from stdin..." 1>&2
-    tokenfile_contents=$(cat)
+    echo "Reading token from stdin. Input is not shown. Continue with the Enter key." 1>&2
+    read -s tokenfile_contents
   else
     $verbose && echo "Token source: $tokenfile"
     tokenfile_contents=$(<"$tokenfile") || {
@@ -380,6 +380,11 @@ else
     exit 1
   fi
   # read BEARER_TOKEN
+fi
+
+if [ -z "$token" ] ; then
+  echo 1>&2 "ERROR: token is empty."
+  exit 1
 fi
 
 check_token "$token" || exit 1

--- a/view-token
+++ b/view-token
@@ -13,10 +13,11 @@ usage() {
 	<filename>     - file containing a token. Can be a plain text file with the bare token,
 	                 or an Rclone config file. In that case, view-token will search for
 	                 a line containing "bearer_token" and decode the value.
-	                 You can use a trick like this:
+	                 If filename is "-" (dash), view-token will read the token from stdin.
+	                 To read the token in a safe way from an environment variable,
+	                 you can use this trick:
 	                     view-token <(cat <<<"\$my_token")
-	                 This allows you to read from a variable without exposing the variable
-	                 to other users with the ps command.
+	                 This will not expose your token to other users with the ps command.
 
 	<no filename>  - view-token will look for environment variable BEARER_TOKEN
 	                 and decode its value.

--- a/view-token
+++ b/view-token
@@ -348,7 +348,7 @@ if [ -n "$tokenfile" ] ; then
   #
   # Read the tokenfile only once (It might be a file descriptor that will be closed after reading)
   if [ "$tokenfile" = "-" ]; then
-    echo "Reading token from stdin. Input is not shown. Continue with the Enter key." 1>&2
+    $verbose && echo "Reading token from stdin. Input is not shown. Continue with the Enter key." 1>&2
     read -s tokenfile_contents
   else
     $verbose && echo "Token source: $tokenfile"

--- a/view-token
+++ b/view-token
@@ -344,13 +344,18 @@ done
 
 
 if [ -n "$tokenfile" ] ; then
-  $verbose && echo "Token source: $tokenfile"
   #
   # Read the tokenfile only once (It might be a file descriptor that will be closed after reading)
-  tokenfile_contents=$(<"$tokenfile") || {
-    echo "ERROR: unable to read token from '$tokenfile'" 1>&2
-    exit 1
-  }
+  if [ "$tokenfile" = "-" ]; then
+    echo "Reading token from stdin..." 1>&2
+    tokenfile_contents=$(cat)
+  else
+    $verbose && echo "Token source: $tokenfile"
+    tokenfile_contents=$(<"$tokenfile") || {
+      echo "ERROR: unable to read token from '$tokenfile'" 1>&2
+      exit 1
+    }
+  fi
   #
   # First, we assume the tokenfile is an Rclone config file.
   token=$(sed -n 's/^bearer_token *= *//p' <<<"$tokenfile_contents")


### PR DESCRIPTION
With `view-token -`, it will read from stdin, so you can copy & paste a token, then press ctrl+d to end the input, and the token should be decoded. Since the token is not provided on the command line, it can't be stolen by other users on the same system with the `ps` command. Convenient and still safe.